### PR TITLE
서비스업체 메인 내 헤더 푸터 충돌 수정

### DIFF
--- a/SsangYongBang/WebContent/WEB-INF/views/service/servicemain.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/service/servicemain.jsp
@@ -9,7 +9,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>servicemain</title>
 
-<%@include file="/WEB-INF/views/inc/asset.jsp" %>
 <link rel="stylesheet" href="/sybang/css/servicemain.css">
 
 
@@ -43,6 +42,8 @@
     });
 
     </script>
+    
+<%@include file="/WEB-INF/views/inc/asset.jsp" %>
 
 
 <style>
@@ -254,7 +255,7 @@
 	<!-- ########## 본문 끝 -->
 	
 	<!-- 푸터가져오기 -->
-   
+   	<%@include file="/WEB-INF/views/inc/footer.jsp"%>
 
 	<script>
 		


### PR DESCRIPTION
Serviecemain.jsp에서 asset.jsp를 include하는 라인이 bootstrap.css를 include하는 라인보다 앞서 있는 바람에 asset.jsp 내부의 main.css에서 bootstrap.css를 덮어쓰는 css가 적용되지 않았었습니다. 이에 asset.css를 include하는 라인을 아래로 내렸습니다.

이에 헤더와 푸터가 정상적인 모습으로 나타나지만, 다른 요소에 문제가 없는 지는 확인하지 못했습니다.
그래서 바로 merge하지 않고, 소리님이 한번 작업하시는 branch에서 include라인 위치를 바꿔보시고 merge할 지 close할 지 선택하시면 됩니다!

만약 merge하신다면 다음 작업 때 header.jsp에 서비스 업체 메뉴로 이동할 수 있도록 a 태그에 링크도 달아주시면 감사하겠습니다. 