### PR TITLE
풀캘린더 DB 연동

### DIFF
--- a/SsangYongBang/WebContent/WEB-INF/views/servicescheduler/servicescheduler2.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/servicescheduler/servicescheduler2.jsp
@@ -149,7 +149,7 @@ td{
 	    	
 	    	<!-- 여기서부터 Ajax로 풀캘린더에 같이 합칠 정보를(이벤트데이터) 가져와야 한다.  -->
 	    	
-	    	events:function(fetchInfo, successCallback, failureCallback) {
+	    	events:function(info, successCallback, failureCallback) {
 	    		alert();
 	    		<!--  이 이벤트는 달력의 이전 달 혹은 다음달 버튼을 누를 때마다 ajax로 받아오는 것임. -->
 	    		$.ajax({

--- a/SsangYongBang/WebContent/WEB-INF/views/servicescheduler/servicescheduler2.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/servicescheduler/servicescheduler2.jsp
@@ -16,6 +16,11 @@
 <link href='/sybang/fullcalendar/main.css' rel='stylesheet' />
 <script src='/sybang/fullcalendar/main.js'></script>
 
+<!-- 풀캘린더의 날짜 data 포맷팅을 위해 필요한 파일 cdn: moment 사용시 필요 -->
+<script src='https://cdn.jsdelivr.net/npm/moment@2.27.0/min/moment.min.js'></script>
+<script src='https://cdn.jsdelivr.net/npm/@fullcalendar/moment@5.5.0/main.global.min.js'></script>
+
+
 
 <style>
 
@@ -137,63 +142,78 @@ td{
 	<!-- 풀캘린더 관련 자바스크립트 -->   
 	<script>
 	
-	  document.addEventListener('DOMContentLoaded', function() {
-		  
-	    var calendarEl = document.getElementById('calendar');
-	    
-	    var calendar = new FullCalendar.Calendar(calendarEl, {
-	      
-	    	//event 소스-> 풀캘린더의 옵션 활용에 대한 내용인 것 같음
-	    	initialView: 'dayGridMonth'
-	    	
-	    	
-	    	<!-- 여기서부터 Ajax로 풀캘린더에 같이 합칠 정보를(이벤트데이터) 가져와야 한다.  -->
-	    	
-	    	events:function(info, successCallback, failureCallback) {
-	    		alert();
-	    		<!--  이 이벤트는 달력의 이전 달 혹은 다음달 버튼을 누를 때마다 ajax로 받아오는 것임. -->
-	    		$.ajax({
-	    			type: 'POST',
-	    			url: '/sybang/servicescheduler/schedulejsondata.do',
-	    			dataType: 'json',
-	    			success:
-	    				function(result) {
-	    				
-	    				var events = []; <!-- events라는 풀캘린더에서 쓰이는 객체를 만든다. -->
-	    				
-	    				if (result != null) {
-	    					
-	    					<!-- 이 부분에서 each로 돌며 정보를 push한다. -->
-	    					$.each(result, function(index, element) {
-	    						
-	    						
-	    						
-	    					}); <!-- each 끝-->
-	    					
-	    					console.log(events); <!-- each로 돌려서 나오는 값을 콘솔에 찍어보기 -->
-	    					
-	    				} //if문 끝 
-	    				successCallback(events);
-	    				//풀캘린더 DOC 설명
-	    				//The successCallback function must be called when the custom event function has generated its events. 
-	    				//It is the event function’s responsibility 
-	    				//to make sure successCallback is being called with an array of parsable Event Objects.
-	    				
-	    				//calendar.render();
-	    				
-	    			}//success: function 끝
-	    			
-	    		}); //ajax 끝
-	    			    		
-	    	}, //events:function 끝
-	    
-	    	
-	    	
-	    }); //new 풀캘린더 끝
-	    
-	    calendar.render(); //캘린더를 만든다.
-	  
-	  });
+    document.addEventListener('DOMContentLoaded', function() {
+    	
+        var calendarEl = document.getElementById('calendar');
+        
+        var calendar = new FullCalendar.Calendar(calendarEl, {
+          
+        	initialView: 'dayGridMonth',
+        	//timeZone: 'local', // the default (unnecessary to specify)
+        	events: function(fetchInfo, successCallback, failureCallback) {
+       			//alert(); //이 function이 제대로 되는지 알림창 띄워보기 -> 제대로 실행 확인
+        		//얼럿 창은 최초 페이지 로딩 시, 월단위를 바뀔때마다 뜬다. -> 이 함수가 실행되는 때
+       			
+       			$.ajax({
+        			type: 'POST',
+        			url: '/sybang/servicescheduler/schedulejsondata.do',
+        			dataType: 'json',
+        			success:
+        				function(result) {
+        				
+        				var events = []; //캘린더의 이벤트 객체(이 것으로 풀캘린더는 달력 내용을 출력)
+						        				
+						if(result != null) {
+	        				
+							$(result).each(function(index, item) {
+	        					
+								//var startdate = moment(item.startdate).format('YYYY-MM-DD');				
+								
+								events.push({
+									title: item.title,
+									//timeZone: local,
+									start: moment(item.startdate).format('YYYY-MM-DD'),
+									
+									//end: enddate,
+									//timeZone: local,
+									url: item.url
+								}); // push하기
+	        					
+	        					
+	        				}); //each 문 끝
+	        				console.log(events);
+	        				//json데이터가 제대로 왔는지 콘솔 확인
+	        				//브라우저 콘솔 
+	        				/*
+	        				0: {title: "신세경님 완료", start: undefined, end: undefined, url: "estimateConstruction0001.jpg"}
+	        				->날짜가 안 뜬다. 포맷팅이 필요하다.. 나머지(고객명 & url은 형식에 맞게끔 제대로 들어갔기 때문에 콘솔 출력되었다)
+	        				*/
+	        				
+	        				//여기 자바 콘솔에서는
+	        				//{"title": "신세경님 완료",
+	        				//"start": "2021-01-11 00:00:00",
+	        				//"end": "2021-01-11 00:00:00",
+	        				//"url": "estimateConstruction0001.jpg"}
+							
+	        				//왜 문자열이 만들어졌는데 -> 브라우저에서는 언디파인드로 뜬는지?...
+	        				//해결중 ->시간의 경우, 자바스크립트의 date 타입? json에서 문자로 넘어간 시간은
+	        			 	//풀캘린더 events가 인식하지 못해 undefined라고 출력된다.
+	        			 	//moment를 이용해서 인식할수 있게 했으나,,,, 자바 콘솔창에 
+	        			 	//db내용이 제대로 출력되나(json)으로 정보 만들었을 땐 이상X
+	        			 	//브라우저 콘솔창에서 현재 날짜로 출력된다 ..
+						} //if문 끝
+						
+						successCallback(events);
+        				//calendar.render();
+        			} //success : function(result)끝
+        		
+        		}); //ajax 끝
+      
+        	} //event: function 끝
+        	
+        });
+        calendar.render();
+      });
 	
 	</script>
  

--- a/SsangYongBang/src/com/test/sist/servicescheduler/ScheduleJsonData.java
+++ b/SsangYongBang/src/com/test/sist/servicescheduler/ScheduleJsonData.java
@@ -2,12 +2,16 @@ package com.test.sist.servicescheduler;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import sun.java2d.opengl.WGLSurfaceData.WGLVSyncOffScreenSurfaceData;
 
 @WebServlet("/servicescheduler/schedulejsondata.do")
 public class ScheduleJsonData extends HttpServlet {
@@ -16,6 +20,7 @@ public class ScheduleJsonData extends HttpServlet {
 	@Override
 	protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
 		
+		HttpSession session = req.getSession();
 
 		//조인해서 가져온 테이블의 select문에서 빼온 정보 (다중값)를 json형식으로 써준다.
 		//버튼을 누를 때마다 여기서 json 정보를 쓴다.
@@ -26,13 +31,43 @@ public class ScheduleJsonData extends HttpServlet {
 		PrintWriter writer = resp.getWriter();
 		
 		//이 밑에 테이블에서 가져올 정보를 얻어오기 위한 매개변수 목록을 쓴다.
+		String approvalFSeq = (String) session.getAttribute("approvalFSeq");
+		//업체 로그인시 담은 세션의 업체승인번호
 		
-		//매개변수 목록 끝
+		//여기 null값인지 확인해보기
+		System.out.println(approvalFSeq);
+		System.out.println("위 숫자 확인-> 업체승인번호가 null인지 확인하기");
 		
 		//DAO와 list를 호출해서 뿌릴 정보의 list를 만든다.
+		SchedulerDAO dao = new SchedulerDAO();
+		ArrayList<SchedulerDTO> list = dao.listPlan(approvalFSeq);
+		
+		System.out.println("json형식으로 만드는 내용물확인해보기");
+		System.out.println("풀캘린더 공식문서에서 보여주는 events 속성이랑 일치하는지, 오타 없는지 점검필요");
+
 		
 		String temp = "";
 		
+		//가져온 정보를 향상된for문을 통해 json 형식 문자열로 만들기
+		//temp += "["; -> event객체 안의 내용을 넢는 거라서 [] 는 붙이지 않아야 함!!!!!!!!
+			for(SchedulerDTO dto : list) {
+				
+				String servicedate = dto.getServiceDate();
+				//일자는 시간을 잘라서 yyyy-mm-dd형태일 때만 event객체가 인식한다.
+				
+				temp += "{";
+				temp += String.format("\"title\": \"%s님 %s\",", dto.getMemberName(), dto.getProgress()); //title: 김00님 완료
+				temp += String.format("\"start\": \"%s\",", servicedate.substring(0, servicedate.length()-9) ); //start: 오라클 내 저장된 시간
+				temp += String.format("\"url\": \"%s\"", dto.getEstimateURL());
+				temp += "}";
+				temp += ",";
+			}
+		
+			
+		temp = temp.substring(0, temp.length() - 1); //마지막에는 더 따라올 {내용물} 가 없기 때문에 ,출력을 자른다.
+		//temp += "]";
+		System.out.println(temp);
+		writer.print(temp);
 		
 		
 		//다 출력 후, 해제하기

--- a/SsangYongBang/src/com/test/sist/servicescheduler/SchedulerDAO.java
+++ b/SsangYongBang/src/com/test/sist/servicescheduler/SchedulerDAO.java
@@ -1,0 +1,78 @@
+package com.test.sist.servicescheduler;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+
+import com.test.sist.DBUtil;
+
+public class SchedulerDAO {
+	
+	private Connection conn;
+	private Statement stat;
+	private PreparedStatement pstat;
+	private ResultSet rs;
+	
+	public SchedulerDAO() {
+		conn = DBUtil.open();
+	}
+	
+	public void close() {
+		try {
+			conn.close();
+		} catch(Exception e) {
+			System.out.println(e);
+		}
+	}
+
+	
+	
+	//schedulerJasonData 에서 호출한 plan 정보 list 가져오는 메서드(매개변수: 로그인한 업체의 승인번호)
+	public ArrayList<SchedulerDTO> listPlan(String approvalFSeq) {
+		
+		try {
+			
+			String sql = String.format("select * from vwplan where ApprovalFseq = %s", approvalFSeq);
+			
+			pstat = conn.prepareStatement(sql);
+			rs = pstat.executeQuery();
+			
+			
+			ArrayList<SchedulerDTO> list = new ArrayList<SchedulerDTO>();
+			
+			
+			while(rs.next()) {
+				
+				SchedulerDTO dto = new SchedulerDTO();
+				
+				dto.setFirmname(rs.getString("firmName"));
+				dto.setApprovalFseq(rs.getString("approvalFseq"));
+				dto.setMemberName(rs.getString("memberName"));
+				dto.setMemberSeq(rs.getString("memberSeq"));
+				dto.setProgress(rs.getString("progress"));
+				dto.setServiceDate(rs.getString("serviceDate"));
+				dto.setEstimateURL(rs.getString("estimateURL"));
+				dto.setEstimate1thSeq(rs.getString("estimate1thSeq"));
+				
+				list.add(dto);
+			}
+			
+			return list;
+			
+		} catch(Exception e) {
+			System.out.println(e + "plan리스트가져오는 DAO메서드에서 에러");
+		}
+		
+		
+		return null;
+	}
+	
+	
+	
+	
+	
+	
+
+}

--- a/SsangYongBang/src/com/test/sist/servicescheduler/SchedulerDTO.java
+++ b/SsangYongBang/src/com/test/sist/servicescheduler/SchedulerDTO.java
@@ -1,0 +1,76 @@
+package com.test.sist.servicescheduler;
+
+public class SchedulerDTO {
+	//https://fullcalendar.io/docs/event-parsing
+	//풀캘린더에서 화면상 일정을 출력하는 events 객체가 가지는 속성들
+	//이중, title( 서비스 예정 /서비스 진행 /서비스 완료), url(견적서 사본)을 공식 속성으로 사용
+	
+	//https://fullcalendar.io/docs/event-object
+	// 캘린더의 이벤트 모델에서 지원되는 속성 외, 
+	//추가속성(비공식)도 사용가능(extendedProps: {} 이 괄호 안에 적으면 된다.)
+	// 추가속성에는 고객명, 견적서 번호를 사용 예정
+	
+	//컬럼은 고객요청서-업체견적서 join
+	//상관서브쿼리로 고객정보/승인업체정보/일정등록 정보를 가져온 view에서 select문으로 정보 추출 예정
+
+	private String firmname; //업체명
+	private String approvalFseq; //업체승인번호
+	private String memberName;  //고객병
+	private String memberSeq; //고객번호
+	private String progress; //진행상태 (예정/진행/완료)
+	private String serviceDate; //일자 
+	private String estimateURL; //견적서 URL
+	private String estimate1thSeq; //견적서번호
+	
+	public String getFirmname() {
+		return firmname;
+	}
+	public void setFirmname(String firmname) {
+		this.firmname = firmname;
+	}
+	public String getApprovalFseq() {
+		return approvalFseq;
+	}
+	public void setApprovalFseq(String approvalFseq) {
+		this.approvalFseq = approvalFseq;
+	}
+	public String getMemberName() {
+		return memberName;
+	}
+	public void setMemberName(String memberName) {
+		this.memberName = memberName;
+	}
+	public String getMemberSeq() {
+		return memberSeq;
+	}
+	public void setMemberSeq(String memberSeq) {
+		this.memberSeq = memberSeq;
+	}
+	public String getProgress() {
+		return progress;
+	}
+	public void setProgress(String progress) {
+		this.progress = progress;
+	}
+	public String getServiceDate() {
+		return serviceDate;
+	}
+	public void setServiceDate(String serviceDate) {
+		this.serviceDate = serviceDate;
+	}
+	public String getEstimateURL() {
+		return estimateURL;
+	}
+	public void setEstimateURL(String estimateURL) {
+		this.estimateURL = estimateURL;
+	}
+	public String getEstimate1thSeq() {
+		return estimate1thSeq;
+	}
+	public void setEstimate1thSeq(String estimate1thSeq) {
+		this.estimate1thSeq = estimate1thSeq;
+	}
+	
+	
+	
+}

--- a/SsangYongBang/src/com/test/sist/servicescheduler/ServiceScheduler.java
+++ b/SsangYongBang/src/com/test/sist/servicescheduler/ServiceScheduler.java
@@ -1,6 +1,7 @@
 package com.test.sist.servicescheduler;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
@@ -13,6 +14,13 @@ import javax.servlet.http.HttpServletResponse;
 public class ServiceScheduler extends HttpServlet {
    
    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+	   
+	   //1. DB작업 -> select 
+	   //2. 결과 + JSP 호출하기
+	   
+	   //SchedulerDAO dao = new SchedulerDAO();
+	   //ArrayList<SchedulerDTO> list = dao.
+	   
 	   
       RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/views/servicescheduler/servicescheduler2.jsp");
       dispatcher.forward(request, response);


### PR DESCRIPTION
DB 내용이 풀캘린더에 출력될 수 있게 했으나.. 일단 더미 양이 5개로 너무 적어서 다른 기능들 완성하고, 
->(풀캘린더에서 DB를 인식하는 객체인 events라는 것이 자바스크립트로 보내지는 date를 제대로 인식하지 못해 생기는 오류) 해결하겠습니다

현재는 업체가 일정 관리 들어가면 등록된 회원의 이름과 해당일의 진행상태(예정 진행 완료) , 클릭하면 견적서 이미지(url)로 이동하게 되어있습니다.(견적서 더미 이미지 지금 없음)