### PR TITLE
전체업체조회+상세조회

### DIFF
--- a/SsangYongBang/WebContent/WEB-INF/views/service/servicestorelist.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/service/servicestorelist.jsp
@@ -125,6 +125,8 @@
 			<c:forEach items="${list}" var="dto">
 			  <div class="storeInfo">
 			    <div class="thumbnail">
+			    <!-- 업체 승인번호를 매개변수로 하여 view 서블릿에 전달하기 -->
+			      <a href="/sybang/service/ServicestoreView.do?approvalFseq=${dto.approvalFSeq}">
 			      <img src="../images/${dto.portfolio}" alt="...">
 			      <!-- 더미 정보의 이미지 경로 수정 필요. ../images/ 글을 붙이거나 서비스 이용 이미지폴더 따로만들어 해당 경로 붙이기 -->
 			      <div class="caption">
@@ -132,6 +134,8 @@
 			        <p>${dto.address}</p>
 			        <p class="introduction">${dto.introduction}</p>
 			      </div>
+			      </a>
+			      
 			    </div>
 			  </div>
 			 

--- a/SsangYongBang/WebContent/WEB-INF/views/service/servicestoreview.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/service/servicestoreview.jsp
@@ -49,6 +49,35 @@
 
 <style>
 
+.thumbnailWrapper {
+	margin-left: 300px;
+	float: left;
+}
+
+.store {
+	
+	width: 300px;
+}
+
+.storeInfo {
+	display: inline-block;
+	float: left;
+	margin-top: 15px;
+	margin-left: 190px;
+	margint-bottom: 15px;
+	border-left: 4px solid #ddd;
+	border-right: 4px solid #ddd;
+	padding-left: 10px;
+	padding-right: 10px;
+	padding-bottom: 20px;
+	border-radius: 10px;
+	
+}
+
+.intro {
+	width: 500px;
+}
+
 </style>
 </head>
 
@@ -84,6 +113,7 @@
 	<h4> <span class="glyphicon glyphicon-search" aria-hidden="true"></span> 전문업체 찾기</h4>
 	</div>
 	
+	<!-- 
 	<div class="row">
 	<form method="get" action="./index.jsp" class="form-inline mt-3">
 		<select name="" class="form-control mx-1 mt-2">
@@ -96,7 +126,7 @@
 
 	</form>
 	</div>
-
+	-->
 
 	<!-- 본문 중간 -->
 	<hr></hr>
@@ -105,21 +135,21 @@
 	    <div class="col-sm-10 text-center"><!-- 전체 컨테이너(12-2)의 8 크기로 띄우게 됨 -->
 			
 	
-				<div class="col-sm-6 col-md-4">
-					<div class="thumbnail">
-						<img src="../images/interior0001.jpg" alt="...">
+				<div class="thumbnailWrapper">
+					<div class="thumbnail store">
+						<img src="../images/${dto.portfolio}" alt="...">
 					</div>
 				</div>
+				<div style="clear: both"></div>
+			<div class="storeInfo">
+				<h3>${dto.id}</h3>
+				<p>${dto.address}</p>
+				<p>후기 등록 개수</p>
+				<p class="intro">${dto.introduction}</p> <!--  회사소개글 -->
+			
 
-				<div>
-					<h3>업체명</h3>
-					<p>주소</p>
-					<p>후기 등록 개수</p>
-					<p>이 업체의 소개글입니다.</p>
-				</div>
 
-
-			<div>
+			<div> <!-- 모달을 감싼 div -->
 							<!-- Button trigger modal -->
 			<button type="button" class="btn btn-primary btn-lg"
 				data-toggle="modal" data-target="#myModal">무료 견적 받아보기</button>
@@ -231,7 +261,7 @@
 			
 			</div>
 		
-		
+			</div> <!-- storeInfo끝 -->
 		
 		
 	</div>
@@ -248,35 +278,21 @@
 	
 	</div>
 	
+	<c:forEach items="${rlist}" var="rdto"> <!-- 넘긴 리뷰 목록을 돌기 -->
 	<hr></hr>
 	<div class="row">
 		<div class="col-sm-9">
-			<h4>김익명<span>2021.02.15</span></h4>
+			<h4>${rdto.memberName}<span>${rdto.regDate}</span></h4>
 			<div class="col-xs-6 col-md-3">
-				<a href="#" class="thumbnail"> <img src="../images/interior0001.jpg" alt="...">
+				<a href="#" class="thumbnail"> <img src="../images/${rdto.contentURL}" alt="...">
 				</a>
 			</div>
-			<p>너무나 만족합니다.</p>
+			<p>${rdto.reviewContent}</p>
 
 		</div>
 	
 	</div>	
-
-	<hr></hr>
-	<div class="row">
-		<div class="col-sm-9">
-			<h4>김익명<span>2021.02.15</span></h4>
-			<div class="col-xs-6 col-md-3">
-				<a href="#" class="thumbnail"> <img src="../images/interior0001.jpg" alt="...">
-				</a>
-			</div>
-			<p>너무나 만족합니다.</p>
-
-		</div>
-	
-	</div>	
-	
-
+	</c:forEach>
 	
 	</div>
 	

--- a/SsangYongBang/src/com/test/sist/service/ServiceBoardDAO.java
+++ b/SsangYongBang/src/com/test/sist/service/ServiceBoardDAO.java
@@ -105,5 +105,82 @@ public class ServiceBoardDAO {
 	
 	
 	
+	//servicestoreview 서블릿에서
+	//업체승인번호를 매개변수로 하여 해당 업체 정보(1줄) 을 가져오는 메서드 호출
+	public ServiceDTO get(String approvalFSeq) {
+
+		try {
+		
+			String sql = "select * from vwFirmInfo where approvalFSeq = ?";
+			//뷰에는 후기 + 한줄 같이 화면에 출력되므로, 후기 목록과 한줄에 대한 select문이 겹치지 않아야 null값으로 화면 안 뜨는 것을 방지 가능.
+			
+			pstat = conn.prepareStatement(sql);
+			pstat.setString(1, approvalFSeq);
+			
+			rs = pstat.executeQuery();
+			
+			if (rs.next()) {
+				
+				ServiceDTO dto = new ServiceDTO();
+				
+				dto.setApprovalFSeq(rs.getString("approvalFSeq"));
+				dto.setIntroduction(rs.getString("introduction"));
+				dto.setId(rs.getString("id"));
+				dto.setEmail(rs.getString("email"));
+				dto.setAddress(rs.getString("address"));
+				dto.setTel(rs.getString("tel"));
+				dto.setPortfolio(rs.getString("portfolio"));//여기까지 회사 정보
+
+				
+				return dto;
+			}
+			
+		} catch(Exception e) {
+			System.out.println(e);
+		}
+		
+		return null;
+	}
+
+	
+	//servicestoreview 서블릿 -> 해당 승인업체 번호의 후기글 목록 가져오는 메서드 호출
+	public ArrayList<ServiceDTO> listReview(String approvalFSeq) {
+		
+		try {
+			String sql = "select * from vwSumInfoReview where approvalFSeq = ?";
+			
+			pstat = conn.prepareStatement(sql);
+			pstat.setString(1, approvalFSeq);
+			
+			rs = pstat.executeQuery();
+			
+			ArrayList<ServiceDTO> rlist = new ArrayList<ServiceDTO>();
+			
+			while (rs.next()) {
+				
+				ServiceDTO dto = new ServiceDTO();
+				
+				
+				//회사의 후기정보
+				dto.setRegDate(rs.getString("regDate"));
+				dto.setReviewContent(rs.getString("reviewContent"));
+				dto.setContentURL(rs.getString("contentURL"));
+				dto.setMemberName(rs.getString("memberName"));
+				dto.setServiceArea(rs.getString("serviceArea"));
+				
+				rlist.add(dto);
+			}
+			
+			return rlist;
+			
+		} catch (Exception e) {
+			System.out.println(e);
+		}
+		
+		return null;
+	}
+	
+	
+	
 	
 }

--- a/SsangYongBang/src/com/test/sist/service/ServiceDTO.java
+++ b/SsangYongBang/src/com/test/sist/service/ServiceDTO.java
@@ -18,6 +18,58 @@ public class ServiceDTO {
 	
 	private String approvalFSeq; //업체승인번호
 	
+	//해당업체의 후기 정보
+	private String completionSeq; //서비스완료번호
+	private String regDate; //후기 작서일
+	private String reviewContent; //후기내용
+	private String contentURL; //후기 사진
+	private String rivewDelFlag; //후기 삭제여부 (0: 등록, 1: 삭제)
+	private String MemberName; //후기 작성자 명
+	private String serviceArea; //고객 요청서 안의 서비스 행할 장소 정보
+	
+	
+	public String getCompletionSeq() {
+		return completionSeq;
+	}
+	public void setCompletionSeq(String completionSeq) {
+		this.completionSeq = completionSeq;
+	}
+	public String getRegDate() {
+		return regDate;
+	}
+	public void setRegDate(String regDate) {
+		this.regDate = regDate;
+	}
+	public String getReviewContent() {
+		return reviewContent;
+	}
+	public void setReviewContent(String reviewContent) {
+		this.reviewContent = reviewContent;
+	}
+	public String getContentURL() {
+		return contentURL;
+	}
+	public void setContentURL(String contentURL) {
+		this.contentURL = contentURL;
+	}
+	public String getRivewDelFlag() {
+		return rivewDelFlag;
+	}
+	public void setRivewDelFlag(String rivewDelFlag) {
+		this.rivewDelFlag = rivewDelFlag;
+	}
+	public String getMemberName() {
+		return MemberName;
+	}
+	public void setMemberName(String memberName) {
+		MemberName = memberName;
+	}
+	public String getServiceArea() {
+		return serviceArea;
+	}
+	public void setServiceArea(String serviceArea) {
+		this.serviceArea = serviceArea;
+	}
 	public String getApprovalFSeq() {
 		return approvalFSeq;
 	}

--- a/SsangYongBang/src/com/test/sist/service/ServicestoreList.java
+++ b/SsangYongBang/src/com/test/sist/service/ServicestoreList.java
@@ -79,11 +79,7 @@ public class ServicestoreList extends HttpServlet {
 		   System.out.println(dto.getCategorySeq() + dto.getApprovalFSeq() + dto.getId() + dto.getAddress() + dto.getPortfolio());
 	   }
 	   /*
-		dto.setApprovalFSeq(rs.getString("approvalFSeq"));
-		dto.setId(rs.getString("id"));
-		dto.setAddress(rs.getString("address"));
-		dto.setPortfolio(rs.getString("portfolio"));
-		dto.setIntroduction(rs.getString("introduction"));
+		콘솔에 해당 정보들이 찍히는 것 확인되었음.
 	   */
 	   
 	   //총 페이지 수 계산

--- a/SsangYongBang/src/com/test/sist/service/ServicestoreView.java
+++ b/SsangYongBang/src/com/test/sist/service/ServicestoreView.java
@@ -1,6 +1,7 @@
 package com.test.sist.service;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
@@ -8,11 +9,52 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 @WebServlet("/service/ServicestoreView.do")
 public class ServicestoreView extends HttpServlet {
    
    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+	   
+	   //1. 데이터 가져오기
+	   //2. DB작업 -> select
+	   //3. 결과 반환 -> JSP 호출하기 + 전달
+	   
+	   HttpSession session = request.getSession();
+	   
+	   
+	   //1.
+	   String approvalFseq = request.getParameter("approvalFseq"); //스트링쿼리로 넘겨받은 업체승인번호
+	   //String search = 
+	   //String page = 
+	   
+	   System.out.println(approvalFseq); //
+	   System.out.println("뷰 화면에서 업체승인번호가 넘어왔는지 콘솔확인(위 번호 확인)");
+	   
+	   //2. 
+	   ServiceBoardDAO dao = new ServiceBoardDAO();
+	   
+	   ServiceDTO dto = dao.get(approvalFseq); //업체승인번호를 매개로 하여 해당업체  가져오는 메서드 호출하기
+	   ArrayList<ServiceDTO> rlist = dao.listReview(approvalFseq);//업체승인번호 매개. 후기 목록 가져오기
+	   //System.out.println(dto.getId() + "해당업체 정보 한 줄 ");
+	   //여기서 계속 오류난다.
+	   
+	   //에러확인 -> rlist로 받아온 정보를 콘솔에서 확인하기
+	   for (ServiceDTO rdto : rlist) {
+		   System.out.println(rdto.getReviewContent() + "리뷰글");
+	   }
+	   
+	   dao.close();
+	   
+	   
+	   //2.5 데이터 조작
+	   
+	   
+	   //3.
+	   request.setAttribute("dto", dto);
+	   request.setAttribute("rlist", rlist);
+	   //request.setAttribute("search", o);
+	   //우선 검색어, 페이징은 넘기지 말고 시연
 	   
       RequestDispatcher dispatcher = request.getRequestDispatcher("/WEB-INF/views/service/servicestoreview.jsp");
       dispatcher.forward(request, response);


### PR DESCRIPTION
전체업체 조회 + 리스트에서 해당 업체 상세조회 기능 구현.

해당업체 상세조회 시.. -> 후기가 같이 출력되도록 했는데 
후기 이미지 경로의 경우, 따로 파일 경로를 지정해야할 필요 있음을 발견.

=> 후기 작성의 경우, 파일을 첨부할 수 있도록 했기 때문에 그 파일이 저장되는 이미지의 경로를 기본 후기 이미지 경로로 하고, 더미 또한 따라서 만들어야 함.
(현재는 아직 후기 이미지의 저장경로를 따로 지정하지 않아 
업체 상세조회 시, 후기 이미지는 깨집니다.)

[중간 정리]

[남은 기능] 
1. 후기 작성/ 조회  / 삭제 
2. 매출조회
3. 업체 회원가입 / 마이페이지 정보 수정
4. 각각의 이미지 경로 파일에 대한 점검 필요


[완료기능]
1. 요청서 전체 리스트 출력
2. 본인한테 온 견적서 출력
3. 요청서 작성 / 견적서 작성
4. 로그인(업체)
5. 접근 access에 따라서 업체 / 회원마다의 view 만들고 그에 맞게 서비스메인 메뉴가 출력되게끔 하기
6. 채팅 리스트  + log 조회 + 작성
7. 풀캘린더 라이브러리 활용하여 달력으로 일정 표시