### PR TITLE
메인화면, 로그인 버튼 크기 수정

### DIFF
--- a/SsangYongBang/WebContent/WEB-INF/views/broker/house/myreglist.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/broker/house/myreglist.jsp
@@ -22,9 +22,10 @@
 		<table class="table table-hover table-type-list">
 			<thead class="board-table-head">
 				<tr>
-					<th scope="col" class="text-center">제목</th>
-					<th scope="col" class="text-center ">주소</th>
-					<th scope="col" class="text-center">작성일</th>
+					<th scope="col" class="text-center col-md-6">제목</th>
+					<th scope="col" class="text-center col-md-3">주소</th>
+					<th scope="col" class="text-center col-md-1">거래 상태</th>
+					<th scope="col" class="text-center col-md-2">작성일</th>
 				</tr>
 			</thead>
 			<tbody class="board-table-body">
@@ -36,6 +37,7 @@
 						</a>
 					</td>
 					<td class="text-center">${hdto.address}</td>
+					<td class="text-center">${hdto.state}</td>
 					<td class="text-center">${hdto.regdate}</td>
 				</tr>
 				</c:forEach>

--- a/SsangYongBang/WebContent/WEB-INF/views/free/list.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/free/list.jsp
@@ -11,6 +11,16 @@
 <link rel="stylesheet" href="/sybang/css/globallist.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css" />
 <style>
+.newBadge {
+	position: relative;
+	top: -5px;
+}
+
+.listContainer .page-header small {
+	position: relative;
+	top: 5px;
+	font-size: 0.6em;
+}
 </style>
 </head>
 <body>
@@ -84,7 +94,7 @@
 					<!-- 댓글 수 끝 -->
 					<!-- 최신 글 시작 -->
 					<c:if test="${dto.gap < 1 }">
-						<span class="badge" style="background-color: red;">N</span></a>
+						<span class="badge newBadge" style="background-color: red;">N</span></a>
 					</c:if>
 					<!-- 최신 글 끝 -->
 					

--- a/SsangYongBang/WebContent/WEB-INF/views/inc/header.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/inc/header.jsp
@@ -26,7 +26,6 @@
           			<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">커뮤니티<span class="caret"></span></a>
 			          	<ul class="dropdown-menu" role="menu">
 				            <li><a href="/sybang/notice/list.do">공지사항</a></li>
-				            <li><a href="/sybang/news/boardList.do">뉴스</a></li>
 				            <li><a href="/sybang/free/list.do">자유게시판</a></li>
 				            <c:if test="${not empty email }">
 				            <li><a href="/sybang/inquiry/list.do">문의게시판</a></li>

--- a/SsangYongBang/WebContent/WEB-INF/views/index.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/index.jsp
@@ -10,7 +10,172 @@
 	<link rel="stylesheet" href="/sybang/css/index.css">
 	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css" />
     <style>
-    </style>
+@import
+	url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap')
+	;
+
+#maincontainer {
+	width: 1200px;
+	margin-left: auto;
+	margin-right: auto;
+	font-family: 'Noto Sans KR', sans-serif;
+	letter-spacing: -1px;
+}
+
+#maincontainer .mainheader .well {
+	outline: none;
+}
+
+/* main-header 시작 */
+#maincontainer .mainheader {
+	text-align: center;
+	margin-top: 30px;
+	height: 50vh;
+	background: url(/sybang/images/bg.jpg) center;
+	background-size: cover;
+	width: 100%;
+	opacity: 1;
+}
+
+/* 어떤 방에 살고 ~~ 텍스트 */
+#maincontainer .mainheader .headertxt {
+	font-weight: bold;
+	margin: 100px;
+	padding-top: 30px;
+	font-size: 3em;
+	color: #EEE;
+	text-shadow: 1px 1px 5px #000;
+}
+
+/* 검색 버튼 */
+#maincontainer .mainheader #searchbtn {
+	width: 35px;
+	height: 35px;
+	display: inline-block;
+	text-align: center;
+	padding: 3px;
+	font-size: 1em;
+	background-color: #486BB8;
+	color: #EEE;
+	outline: none;
+	border-radius: 50%;
+}
+
+#maincontainer .mainheader #searchbtn:hover {
+	background: none;
+	border: 3px solid #486BB8;
+}
+
+/* mainhistory(방금 올라온 매물, 찜한 매물) 시작 */
+#maincontainer .mainhistory {
+	width: 100%;
+	height: 48vh;
+	margin: 10px auto;
+	text-align: center;
+}
+
+#maincontainer .mainhistory .newBadge {
+	position: relative;
+	top: -10px;
+}
+
+#maincontainer .mainhistory .newsTable {
+	display: inline;
+	margin-left: 30px;
+	margin-right: 30px;
+}
+
+#maincontainer .mainhistory th {
+	font-size: 1.3em;
+	height: 40px;
+	background-color: #EEE;
+}
+
+#maincontainer .mainhistory td {
+	height: 30px;
+	text-decoration: none;
+	text-align: center;
+	font-size: 1.1em;
+}
+
+#maincontainer .mainhistory a {
+	color: #000;
+}
+
+#maincontainer .mainhistory a:hover {
+	color: #486BB8;
+	text-decoration-line: none;
+}
+
+/* 사진 */
+#maincontainer .mainhistory .thumbnail {
+	height: 100px;
+}
+
+#maincontainer .mainhistory small, #maincontainer .mainnotice small {
+	margin-right: 20px;
+	float: right;
+	font-size: 0.9em;
+}
+
+/* mainnotice 시작 */
+#maincontainer .mainnotice {
+	width: 100%;
+	height: 40vh;
+	margin: 5px auto;
+}
+
+#maincontainer .mainnotice .noticeTable {
+	display: inline-block;
+	margin-left: 20px;
+	margin-right: 15px;
+	width: 350px;
+	height: 350px;
+}
+
+#maincontainer .mainnotice .noticeTable .box {
+	width: 340px;
+	height: 200px;
+	overflow: hidden;
+}
+
+#maincontainer .mainnotice .noticeTable .box #innerbox {
+	width: 340px;
+}
+
+#maincontainer .mainnotice .noticeTable .thumbnail {
+	width: 340px;
+	margin: 0px auto;
+}
+
+#maincontainer .mainnotice th {
+	width: 30%;
+	margin-left: 10px;
+	font-size: 1.3em;
+	border: 0px;
+	text-align: center;
+}
+
+#maincontainer .mainnotice td {
+	margin-left: 10px;
+	font-size: 1.1em;
+	text-align: center;
+}
+
+#maincontainer .mainnotice a {
+	color: #000;
+}
+
+#maincontainer .mainnotice a:hover {
+	color: #486BB8;
+	text-decoration-line: none;
+}
+
+.bluebg {
+	background-color: #486BB8;
+	color: #EEE;
+}
+</style>
 </head>
 
 <body>
@@ -18,18 +183,18 @@
 	<!-- header 가져오기######## -->
    	<%@include file="/WEB-INF/views/inc/header.jsp"%>
 	
-    <!-- maincontainer 시작 -->
+	    <!-- maincontainer 시작 -->
     <main class="container" id="maincontainer">
-
+        
         <!-- mainheader 시작 -->
         <header class="jumbotron mainheader">
             <h1 class="headertxt">어떤 집에서 살고 싶으신가요?</h1>
             <div>
-            
-                <!-- 검색 form 태그 시작 -->
-                <form method="GET" action="/sybang/index.do">
-                <input type="text" name="search" id="search" class="well well-sm" placeholder="원하시는 지역명, 지하철역, 단지명(아파트명)을 입력해주세요." size="60" style="font-size: 1.2em;">
-               
+                <!-- form 태그 시작 -->
+                <form method="POST" action="">
+                    <input type="text" class="well well-sm" placeholder="원하시는 지역명, 지하철역, 단지명(아파트명)을 입력해주세요." size="60"
+                        style="font-size: 1.2em;">
+
                     <button type="submit" id="searchbtn" class="form-control"><i class="fas fa-search"></i></button>
                 </form>
                 <!-- form 태그 끝 -->
@@ -39,13 +204,12 @@
 
         <!-- mainhistory 시작 -->
         <section class="mainhistory">
-            <table class="table table-default">
+            <table class="table table-default newsTable">
 
                 <tr>
-                    <th colspan="3">최근 본 매물</th>
-                    <th colspan="3">찜한 매물</th>
+                    <th colspan="3">방금 올라온 매물 <span class="badge newBadge" style="background-color: red;">N</span></th>
                 </tr>
-                
+
                 <tr>
                     <!-- 최근 본 매물 사진 시작 -->
                     <td>
@@ -60,11 +224,44 @@
                     </td>
                     <td>
                         <a href="#">
+                            <img src="/sybang/images/room01.jpg" class="thumbnail">
+                        </a>
+                    </td>
+
+                <tr>
+                    <td><a href="#">빌라/투룸<small>26㎡ 5층</small></a></td>
+                    <td><a href="#">빌라/투룸<small>26㎡ 5층</small></a></td>
+                    <td><a href="#">빌라/투룸<small>26㎡ 5층</small></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#"><b>매매 2억 6,000</b></a></td>
+                    <td><a href="#"><b>매매 2억 6,000</b></a></td>
+                    <td><a href="#"><b>매매 2억 6,000</b></a></td>
+                </tr>
+                <tr>
+                    <td><a href="#">강남구 논현동</a></td>
+                    <td><a href="#">강남구 논현동</a></td>
+                    <td><a href="#">강남구 논현동</a></td>
+                </tr>
+                <tr>
+                    <td><a href="#">★테라스 있는 신축</a></td>
+                    <td><a href="#">★테라스 있는 신축</a></td>
+                    <td><a href="#">★테라스 있는 신축</a></td>
+                </tr>
+            </table>
+            <table class="table table-default newsTable">
+
+                <tr>
+                    <th colspan="3">최근 본 매물</th>
+                </tr>
+
+                <tr>
+                    <!-- 최근 본 매물 사진 시작 -->
+                    <td>
+                        <a href="#">
                             <img src="/sybang/images/room03.jpg" class="thumbnail">
                         </a>
                     </td>
-                    <!-- 최근 본 매물 사진 끝-->
-                    <!-- 찜한 매물 사진 시작 -->
                     <td>
                         <a href="#">
                             <img src="/sybang/images/room01.jpg" class="thumbnail">
@@ -75,17 +272,8 @@
                             <img src="/sybang/images/room03.jpg" class="thumbnail">
                         </a>
                     </td>
-                    <td>
-                        <a href="#">
-                            <img src="/sybang/images/room03.jpg" class="thumbnail">
-                        </a>
-                    </td>
-                    <!-- 찜한 매물 사진 끝 -->
-                </tr>
+
                 <tr>
-                    <td><a href="#">빌라/투룸<small>26㎡ 5층</small></a></td>
-                    <td><a href="#">빌라/투룸<small>26㎡ 5층</small></a></td>
-                    <td><a href="#">빌라/투룸<small>26㎡ 5층</small></a></td>
                     <td><a href="#">빌라/투룸<small>26㎡ 5층</small></a></td>
                     <td><a href="#">빌라/투룸<small>26㎡ 5층</small></a></td>
                     <td><a href="#">빌라/투룸<small>26㎡ 5층</small></a></td>
@@ -94,27 +282,20 @@
                     <td><a href="#"><b>매매 2억 6,000</b></a></td>
                     <td><a href="#"><b>매매 2억 6,000</b></a></td>
                     <td><a href="#"><b>매매 2억 6,000</b></a></td>
-                    <td><a href="#"><b>매매 2억 6,000</b></a></td>
-                    <td><a href="#"><b>매매 2억 6,000</b></a></td>
-                    <td><a href="#"><b>매매 2억 6,000</b></a></td>
                 </tr>
                 <tr>
                     <td><a href="#">강남구 논현동</a></td>
                     <td><a href="#">강남구 논현동</a></td>
                     <td><a href="#">강남구 논현동</a></td>
-                    <td><a href="#">강남구 논현동</a></td>
-                    <td><a href="#">강남구 논현동</a></td>
-                    <td><a href="#">강남구 논현동</a></td>
                 </tr>
                 <tr>
-                    <td><a href="#">★테라스 있는 신축</a></td>
-                    <td><a href="#">★테라스 있는 신축</a></td>
-                    <td><a href="#">★테라스 있는 신축</a></td>
                     <td><a href="#">★테라스 있는 신축</a></td>
                     <td><a href="#">★테라스 있는 신축</a></td>
                     <td><a href="#">★테라스 있는 신축</a></td>
                 </tr>
             </table>
+
+
         </section>
         <!-- mainhistory 끝 -->
 
@@ -122,170 +303,84 @@
 
         <!-- mainnotice 시작 -->
         <section class="row mainnotice">
-            <table class="table table-default">
+
+            <table class="table table-default noticeTable">
                 <tr>
-                    <th>바로가기</th>
-                    <th>공지사항
-                        <small><a href="/sybang/notice/list.do">더보기<span class="glyphicon glyphicon-chevron-right"></span></a></small>
-                    </th>
-                    <th>뉴스
-                        <small><a href="/sybang/news/boardList.do">더보기<span class="glyphicon glyphicon-chevron-right"></span></a></small>
-                    </th>
+                    <th><div>뉴스</div></th>
                 </tr>
                 <tr>
-                    <td>
-                        <button type="button" class="btn btn-default">
-                            <a href="/sybang/service/ServicestoreList.do"><span class="glyphicon glyphicon-briefcase"></span>&nbsp;전문 업체 찾기</a>
-                        </button>
-                    </td>
-                    <td><a href="#">공지사항입니다.</a></td>
-                    <td><a href="#">뉴스입니다.</a></td>
-                </tr>
-                <tr>
-                    <td>
-                        <!-- 1:1 문의 modal 시작 -->
-                        <button id="chat" type="button" class="btn btn-default" data-toggle="modal"
-                            data-target="#modalchat">
-                            <span class="glyphicon glyphicon-user"></span> 1:1 문의하기
-                        </button>
-
-                        <div class="modal fade" role="diaglog" data-keyboard="true" id="modalchat">
-                            <div class="modal-dialog">
-
-                                <div class="modal-content">
-                                    <div class="modal-header">
-                                        
-                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
-                                        
-                                        <h3 class="modal-title" style="text-align: center;">1:1 문의하기</h3>
-                                    </div>
-
-                                    <!-- 문의 내용 -->
-                                    <form method="POST" action="/sybang/member/chat/chatok.do">
-                                    <div class="modal-body">
-                                        <select name="bname" id="bname" class="form-control" >
-                                            <option>승인중개사선택</option>
-                                            <option>중개사이름</option>
-                                            <option>중개사이름</option>
-                                        </select>
-                                        <input name="subject" id="subject" type="text" class="form-control" placeholder="제목을 입력해주세요.">
-                                        <textarea name="content" id="content" class="form-control" cols="50" rows="10" placeholder="문의 내용을 입력해주세요."
-                                            style="resize: none; overflow: visible;"></textarea>
-                                    </div>
-                                    <div class="modal-footer">
-                                        <button type="submit" class="btn btn-success" data-dismiss="modal">등록</button>
-                                        <button type="button" class="btn btn-default" data-dismiss="modal">닫기</button>
-                                    </div>
-                                    </form>
-                                </div>
+                    <td rowspan="5">
+                        <div class="box">
+                            <div id="innerbox">
+                                <marquee behavior="scroll" direction="up" scrollamount="10">
+                                <img src="/sybang/images/notice001.png" class="thumbnail">
+                                <img src="/sybang/images/notice002.png" class="thumbnail">
+                                <img src="/sybang/images/notice003.png" class="thumbnail">
+                                <img src="/sybang/images/notice001.png" class="thumbnail">
+                                <img src="/sybang/images/notice002.png" class="thumbnail">
+                                <img src="/sybang/images/notice003.png" class="thumbnail">
+                                </marquee>
                             </div>
-
                         </div>
-                        <!-- 1:1 문의 modal 끝 -->
-
                     </td>
-                    <td><a href="#">공지사항입니다.</a></td>
-                    <td><a href="#">뉴스입니다.</a></td>
-                </tr>
-                <tr>
-                    <td>
-                    	  <!-- 1:1 문의 내역 modal 시작 -->
-                        <button id="chatlist" type="button" class="btn btn-default" data-toggle="modal"
-                            data-target="#modalchatlist">
-                            <span class="glyphicon glyphicon-book"></span> 1:1 문의내역
-                        </button>
-
-                        <div class="modal fade" role="diaglog" data-keyboard="true" id="modalchatlist">
-                            <div class="modal-dialog">
-
-                                <div class="modal-content">
-                                    <div class="modal-header">
-
-                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
-
-                                        <h3 class="modal-title" style="text-align: center;">1:1 문의내역</h3>
-                                    </div>
-
-                                    <!-- 문의 내용 -->
-                                    <form method="">
-                                        <div class="modal-body">
-                                            <select name="bname" id="bname" class="form-control">
-                                                <option>승인중개사선택</option>
-                                                <option>중개사이름</option>
-                                                <option>중개사이름</option>
-                                            </select>
-                                            <input name="subject" id="subject" type="text" class="form-control"
-                                                placeholder="제목을 입력해주세요.">
-                                            <textarea name="content" id="content" class="form-control" cols="50"
-                                                rows="10" placeholder="문의 내용을 입력해주세요."
-                                                style="resize: none; overflow: visible;"></textarea>
-                                        </div>
-                                        <div class="modal-footer">
-                                            <button type="submit" class="btn btn-success"
-                                                data-dismiss="modal">등록</button>
-                                            <button type="button" class="btn btn-default"
-                                                data-dismiss="modal">닫기</button>
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-
-                        </div>
-                        <!-- 1:1 문의 내역 modal 끝 -->
-                    </td>
-                    <td><a href="#">공지사항입니다.</a></td>
-                    <td><a href="#">뉴스입니다.</a></td>
-                </tr>
-                <tr>
-                    <td>
-                    	<!-- 자주 묻는 질문 modal 시작 -->
-                        <button id="qna" type="button" class="btn btn-default" data-toggle="modal"
-                            data-target="#modalqna">
-                            <span class="glyphicon glyphicon-list"></span>&nbsp;자주 묻는 질문
-                        </button>
-
-                        <div class="modal fade" role="diaglog" data-keyboard="true" id="modalqna">
-                            <div class="modal-dialog">
-
-                                <div class="modal-content">
-                                    <div class="modal-header">
-
-                                        <button type="button" class="close" data-dismiss="modal">&times;</button>
-
-                                        <h3 class="modal-title" style="text-align: center;">자주 묻는 질문</h3>
-                                    </div>
-
-                                    <!-- 문의 내용 -->
-                                    <form method="">
-                                        <div class="modal-body">
-                                            <select name="bname" id="bname" class="form-control">
-                                                <option>승인중개사선택</option>
-                                                <option>중개사이름</option>
-                                                <option>중개사이름</option>
-                                            </select>
-                                            <input name="subject" id="subject" type="text" class="form-control"
-                                                placeholder="제목을 입력해주세요.">
-                                            <textarea name="content" id="content" class="form-control" cols="50"
-                                                rows="10" placeholder="문의 내용을 입력해주세요."
-                                                style="resize: none; overflow: visible;"></textarea>
-                                        </div>
-                                        <div class="modal-footer">
-                                            <button type="submit" class="btn btn-success"
-                                                data-dismiss="modal">등록</button>
-                                            <button type="button" class="btn btn-default"
-                                                data-dismiss="modal">닫기</button>
-                                        </div>
-                                    </form>
-                                </div>
-                            </div>
-
-                        </div>
-                        <!-- 자주 묻는 질문 modal 끝 -->
-                    </td>
-                    <td><a href="#">공지사항입니다.</a></td>
-                    <td><a href="#">뉴스입니다.</a></td>
                 </tr>
             </table>
+
+            <table class="table table-default noticeTable">
+                <tr>
+                    <th class="well">인기글</th>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+            </table>
+
+            <table class="table table-default noticeTable">
+                <tr>
+                    <th class="well">최신글</th>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a href="/sybang/service/ServicestoreList.do"> 제목입니다자유겟판</a>
+                    </td>
+                </tr>
+            </table>
+
+            
+
+            
         </section>
         <!-- mainnotice 끝 -->
 

--- a/SsangYongBang/WebContent/WEB-INF/views/inquiry/list.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/inquiry/list.jsp
@@ -12,6 +12,15 @@
 <link rel="stylesheet"
 	href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css" />
 <style>
+.newBadge {
+	position: relative;
+	top: -5px;
+}
+.listContainer .page-header small {
+	position: relative;
+	top: 5px;
+	font-size: 0.6em;
+}
 </style>
 </head>
 <body>
@@ -88,7 +97,7 @@
 					<!-- 댓글 수 끝 -->
 					<!-- 최신 글 시작 -->
 					<c:if test="${dto.gap < 1 }">
-						<span class="badge" style="background-color: red;">N</span>
+						<span class="badge newBadge" style="background-color: red;">N</span>
 					</c:if>
 					<!-- 최신 글 끝 -->
 					</a>

--- a/SsangYongBang/WebContent/WEB-INF/views/login/loginbuttons.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/login/loginbuttons.jsp
@@ -9,19 +9,23 @@
 <%@include file="/WEB-INF/views/inc/asset.jsp"%>
 <link rel="stylesheet" href="/sybang/css/memberlogin.css">
 <style>
-
 .login-buttons .jumbotron div:first-child {
-    width: 500px;
-    padding-top: 30px;
-    display: inline-block;
+	width: 500px;
+	padding-top: 30px;
+	display: inline-block;
 }
 
-.login-buttons .btn-lg, .btn-group-lg > .btn {
-    width: 200px;
-    height: 100px;
-    margin: 10px 20px;
+.login-buttons .btn-lg, .btn-group-lg>.btn {
+	width: 200px;
+	height: 100px;
+	margin: 10px 20px;
 }
 
+#mlogin {
+	width: 200px;
+	height: 100px;
+	margin: 10px 20px;
+}
 </style>
 </head>
 
@@ -41,7 +45,7 @@
                       
             <div class="buttons">
   				<button type="button" class="btn btn-primary btn-lg" onclick="location.href='/sybang/broker/auth.do'">부동산 중개사 로그인</button>
-  				<button type="button" class="btn btn-info btn-lg" onclick="location.href='/sybang/member/login.do'">회원 로그인</button>
+  				<button type="button" class="btn btn-info btn-lg" id="mlogin" onclick="location.href='/sybang/member/login.do'">회원 로그인</button>
   				<button type="button" class="btn btn-success btn-lg" onclick="location.href='/sybang/service/auth.do'">서비스업체 로그인</button>
   				<button type="button" class="btn btn-danger btn-lg" onclick="location.href='/sybang/admin/auth.do'">관리자 로그인</button>
 			</div>

--- a/SsangYongBang/WebContent/WEB-INF/views/member/login.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/member/login.jsp
@@ -73,10 +73,15 @@
 	height: 100px;
 	font-size: 1.3em;
 	background-color: #3B79BC;
+	opacity: .8;
 }
 
 .list-container .btn-info:hover {
-	opacity: .8;
+	width: 150px;
+	height: 100px;
+	font-size: 1.3em;
+	background-color: #3B79BC;
+	opacity: 1;
 }
 </style>
 </head>
@@ -90,7 +95,6 @@
 	<div class="list-container" style="margin-top: -50px;">
 		<div class="page-header">
 			<h1>로그인</h1>
-			<!-- <div class="well well-sm" style="float:left;">총 <b>5</b>개의 자유게시판 글이 등록되어 있습니다.</div> -->
 		</div>
 
 		<div class="jumbotron">
@@ -134,12 +138,5 @@
 
 	<!-- footer 가져오기######## -->
 	<%@include file="/WEB-INF/views/inc/footer.jsp"%>
-	<script>
-	   	function test(id, pw) {
-	   		$("#email").val(id);
-	   		$("#pw").val(pw);
-	   		$("#login-form").submit(); 
-	   	}
-   </script>
 </body>
 </html>

--- a/SsangYongBang/WebContent/WEB-INF/views/member/myinfo.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/member/myinfo.jsp
@@ -54,7 +54,7 @@
             <!-- 내가 쓴 글 시작 -->
             <div class="tab-pane fade in active" id="writepost">
             	<div id="btn-post">
-                        <button type="button" class="btn btn-default">
+                        <button type="button" class="btn btn-default" id="ckAll">
                             <span class="glyphicon glyphicon-ok"></span> 전체 선택
                         </button>
                         <button type="button" class="btn btn-default">
@@ -65,7 +65,7 @@
                 <table class="table table-condensed" id="tbl-post">
                     
                     <tr>
-                        <th><input type="checkbox"></th>
+                        <th></th>
                         <th>번호</th>
                         <th>제목</th>
                         <th>작성일</th>
@@ -75,7 +75,7 @@
                     <!-- 받아온 내가 쓴 글 목록을 forEach로  -->
                     <c:forEach items="${plist }" var="pdto">
                     <tr>
-                        <td><input type="checkbox"></td>
+                        <td><input type="checkbox" class="ckItem"></td>
                         <td>${pdto.seq }</td>
 						<!-- 해당 글이 자유게시판 글일 경우 -->
                         <c:if test="${pdto.which eq '자유게시판' }">
@@ -228,6 +228,16 @@
 	<%@include file="/WEB-INF/views/inc/footer.jsp"%>
 	
 	<script>
+	
+		$("#ckAll").click(function(){
+			
+			
+			if ($(".ckItem").prop("checked")) {
+				$(".ckItem").prop("checked", false);	
+			} else {
+				$(".ckItem").prop("checked", true);
+			}
+		});
 	
 		
 	

--- a/SsangYongBang/WebContent/WEB-INF/views/notice/list.jsp
+++ b/SsangYongBang/WebContent/WEB-INF/views/notice/list.jsp
@@ -46,6 +46,11 @@
 	font-size: 1em;
 	color: #444;
 }
+.listContainer .page-header small {
+	position: relative;
+	top: 5px;
+	font-size: 0.6em;
+}
 </style>
 </head>
 <body>

--- a/SsangYongBang/WebContent/css/globallist.css
+++ b/SsangYongBang/WebContent/css/globallist.css
@@ -47,7 +47,7 @@ body {
 .listContainer .page-header small {
 	position: relative;
 	top: 5px;
-	font-size: 0.8em;
+	font-size: 0.7em;
 }
 
 .listContainer .searchTable #search {

--- a/SsangYongBang/WebContent/css/index.css
+++ b/SsangYongBang/WebContent/css/index.css
@@ -1,7 +1,8 @@
 @charset "UTF-8";
 
 @import
-	url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap');
+	url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap')
+	;
 
 #maincontainer {
 	width: 1200px;
@@ -20,7 +21,7 @@
 	text-align: center;
 	margin-top: 30px;
 	height: 50vh;
-	background: url(/sybang/images/mainbg.jpg) center;
+	background: url(/images/bg.jpg) center;
 	background-size: cover;
 	width: 100%;
 	opacity: 1;
@@ -53,11 +54,23 @@
 	border: 3px solid #486BB8;
 }
 
-/* mainhistory(최근에 본 매물, 찜한 매물) 시작 */
+/* mainhistory(방금 올라온 매물, 찜한 매물) 시작 */
 #maincontainer .mainhistory {
-	width: 90%;
-	height: 40vh;
+	width: 100%;
+	height: 48vh;
 	margin: 10px auto;
+	text-align: center;
+}
+
+#maincontainer .mainhistory .newBadge {
+	position: relative;
+	top: -10px;
+}
+
+#maincontainer .mainhistory .newsTable {
+	display: inline;
+	margin-left: 30px;
+	margin-right: 30px;
 }
 
 #maincontainer .mainhistory th {
@@ -95,22 +108,46 @@
 
 /* mainnotice 시작 */
 #maincontainer .mainnotice {
-	width: 90%;
-	height: auto;
-	margin: 10px auto;
+	width: 100%;
+	height: 40vh;
+	margin: 5px auto;
+}
+
+#maincontainer .mainnotice .noticeTable {
+	display: inline-block;
+	margin-left: 20px;
+	margin-right: 15px;
+	width: 350px;
+	height: 350px;
+}
+
+#maincontainer .mainnotice .noticeTable .box {
+	width: 340px;
+	height: 200px;
+	overflow: hidden;
+}
+
+#maincontainer .mainnotice .noticeTable .box #innerbox {
+	width: 340px;
+}
+
+#maincontainer .mainnotice .noticeTable .thumbnail {
+	height: 100%;
+	margin: 0px auto;
 }
 
 #maincontainer .mainnotice th {
 	width: 30%;
 	margin-left: 10px;
 	font-size: 1.3em;
-	background-color: #EEE;
+	border: 0px;
 	text-align: center;
 }
 
 #maincontainer .mainnotice td {
-	margin-left: 30px;
+	margin-left: 10px;
 	font-size: 1.1em;
+	text-align: center;
 }
 
 #maincontainer .mainnotice a {
@@ -120,4 +157,9 @@
 #maincontainer .mainnotice a:hover {
 	color: #486BB8;
 	text-decoration-line: none;
+}
+
+.bluebg {
+	background-color: #486BB8;
+	color: #EEE;
 }

--- a/SsangYongBang/WebContent/css/memberlogin.css
+++ b/SsangYongBang/WebContent/css/memberlogin.css
@@ -59,18 +59,3 @@
 	padding-top: 15px;
 }
 
-.list-container .btn-info {
-	width: 200px;
-	height: 100px;
-	font-size: 1.3em;
-	background-color: #3B79BC;
-	opacity: .8;
-}
-
-.list-container .btn-info:hover {
-	width: 150px;
-	height: 100px;
-	font-size: 1.3em;
-	background-color: #3B79BC;
-	opacity: 1;
-}

--- a/SsangYongBang/src/com/test/sist/house/dao/HouseDAO.java
+++ b/SsangYongBang/src/com/test/sist/house/dao/HouseDAO.java
@@ -118,7 +118,8 @@ public class HouseDAO {
 	//MyRegList 서블릿 -> 게시글 목록 반환
 	public ArrayList<HouseDTO> list(HashMap<String, String> map) {
 		try {
-			String sql = "select * from (select rownum as rnum, h.* from vwHousePost h where h.bseq = ?) where rnum between ? and ?";
+			String sql = "select seq, bseq, subject, address, to_char(regdate, 'yy/mm/dd') as regdate, state "
+					+ " from (select rownum as rnum, h.* from vwHousePost h where h.bseq = ?) where rnum between ? and ?";
 			pstat = conn.prepareStatement(sql);
 			pstat.setString(1, map.get("bseq"));
 			pstat.setString(2, map.get("begin"));
@@ -135,7 +136,8 @@ public class HouseDAO {
 				dto.setBseq(rs.getString("bseq")); //승인 중개사 번호
 				dto.setSubject(rs.getString("subject"));
 				dto.setAddress(rs.getString("address"));
-				dto.setRegdate(rs.getString("regdate").substring(0, 10));
+				dto.setRegdate(rs.getString("regdate"));
+				dto.setState(rs.getString("state"));
 				
 				list.add(dto);
 			}

--- a/SsangYongBang/src/com/test/sist/member/LoginOk.java
+++ b/SsangYongBang/src/com/test/sist/member/LoginOk.java
@@ -56,11 +56,11 @@ public class LoginOk extends HttpServlet {
 			
 		} else {
 			//로그인 실패 시
+			resp.setContentType("text/html; charset=UTF-8");
 			PrintWriter writer = resp.getWriter();
-			
 			writer.print("<html><body>");
 			writer.print("<script>");
-			writer.print("alert('failed');");
+			writer.print("alert('아이디나 비밀번호를 확인하여주세요.');");
 			writer.print("history.back();");
 			writer.print("</script>");
 			writer.print("</body></html>");

--- a/SsangYongBang/src/com/test/sist/member/chat/ChatDAO.java
+++ b/SsangYongBang/src/com/test/sist/member/chat/ChatDAO.java
@@ -39,10 +39,10 @@ public class ChatDAO {
 		try {
 			
 			String sql = "select "
-					+ "    ab.seq as abseq,"
-					+ "    b.businessName as bname"
-					+ "from tblApproBroker ab inner join tblBroker b on ab.brokerSeq = b.seq"
-					+ "where b.delFlag = 0;";
+					+ "    ab.seq as abseq, "
+					+ "    b.businessName as bname "
+					+ " from tblApproBroker ab inner join tblBroker b on ab.brokerSeq = b.seq"
+					+ " where b.delFlag = 0";
 			
 			stat = conn.createStatement();
 			rs = stat.executeQuery(sql);


### PR DESCRIPTION
* 회원 로그인 버튼 크기가 혼자 이상하여 수정했습니다.
* JDBC 연결 과정에서 세미콜론이 들어가 오류가 발생한 것을 모르고 있었고 삭제했습니다.
* 메인 화면 수정했습니다.

내일까지 할 예정인 구현은
1. 내 정보 관리에서 내가 쓴 댓글, 내 후기/평점 페이지바랑 해당 게시글로 이동
2. 내 정보 관리에서 내 정보 수정 기능
3. 메인에서 방금 올라온 매물, 최신글, 인기글 구현
4. 커뮤니티 탭에서 제외하고 메인으로 온 뉴스는 이미지를 클릭하면 모달로 상세 설명을 볼 수 있게 구현

여기까지이고 아직 안 한 기능들은
1.  최근 본 매물은 DB에 저장해두고 가져와야 하기 때문에 테이블을 추가할 지는 생각해보겠습니다.
2. 회원가입, 아이디찾기, 비밀번호 찾기
3. 중개사쪽에서 매물 게시글 수정
이 정도인 것 같습니다.

기타 사용했던 쿼리는 구글 드라이브 DML 폴더에 최신순으로 보면 있습니다.